### PR TITLE
feat: update flutter local notification version fix crash pending intent

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.3.2"
+    version: "0.5.0"
   analyzer:
     dependency: transitive
     description:
@@ -175,7 +175,7 @@ packages:
       name: dbus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.6"
+    version: "0.7.3"
   dio:
     dependency: transitive
     description:
@@ -215,21 +215,21 @@ packages:
       name: flutter_local_notifications
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "9.0.0"
+    version: "10.0.0"
   flutter_local_notifications_linux:
     dependency: transitive
     description:
       name: flutter_local_notifications_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "1.0.0"
   flutter_local_notifications_platform_interface:
     dependency: transitive
     description:
       name: flutter_local_notifications_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.0"
+    version: "6.0.0"
   flutter_web_plugins:
     dependency: transitive
     description: flutter
@@ -438,13 +438,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.7"
-  pedantic:
-    dependency: transitive
-    description:
-      name: pedantic
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.11.1"
   permission_handler:
     dependency: transitive
     description:

--- a/lib/core/alice_core.dart
+++ b/lib/core/alice_core.dart
@@ -79,14 +79,19 @@ class AliceCore {
     _flutterLocalNotificationsPlugin = FlutterLocalNotificationsPlugin();
     final initializationSettingsAndroid =
         AndroidInitializationSettings(notificationIcon);
-    const initializationSettingsIOS = IOSInitializationSettings();
+    const initializationSettingsIOS = DarwinInitializationSettings();
     final initializationSettings = InitializationSettings(
       android: initializationSettingsAndroid,
       iOS: initializationSettingsIOS,
     );
     _flutterLocalNotificationsPlugin.initialize(
       initializationSettings,
-      onSelectNotification: _onSelectedNotification,
+      onDidReceiveBackgroundNotificationResponse: (data) async {
+        _onSelectedNotification(data.payload);
+      },
+      onDidReceiveNotificationResponse: (data) {
+        _onSelectedNotification(data.payload);
+      }
     );
   }
 
@@ -206,7 +211,7 @@ class AliceCore {
       playSound: false,
       largeIcon: DrawableResourceAndroidBitmap(notificationIcon),
     );
-    const iOSPlatformChannelSpecifics = IOSNotificationDetails(
+    const iOSPlatformChannelSpecifics = DarwinNotificationDetails(
         presentSound: false,
         presentAlert: true,
         presentBadge: false,

--- a/lib/ui/page/alice_calls_list_screen.dart
+++ b/lib/ui/page/alice_calls_list_screen.dart
@@ -57,7 +57,7 @@ class _AliceCallsListScreenState extends State<AliceCallsListScreen>
       length: _tabItems.length,
       initialIndex: _tabItems.first.index,
     );
-    WidgetsBinding.instance.addPostFrameCallback((_) {
+    WidgetsBinding.instance?.addPostFrameCallback((_) {
       _tabController?.addListener(() {
         _onTabChanged(_tabController!.index);
       });

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -56,7 +56,7 @@ packages:
       name: dbus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.6"
+    version: "0.7.3"
   dio:
     dependency: "direct main"
     description:
@@ -89,21 +89,21 @@ packages:
       name: flutter_local_notifications
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "9.0.0"
+    version: "10.0.0"
   flutter_local_notifications_linux:
     dependency: transitive
     description:
       name: flutter_local_notifications_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "1.0.0"
   flutter_local_notifications_platform_interface:
     dependency: transitive
     description:
       name: flutter_local_notifications_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.0"
+    version: "6.0.0"
   flutter_web_plugins:
     dependency: transitive
     description: flutter
@@ -263,13 +263,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.7"
-  pedantic:
-    dependency: transitive
-    description:
-      name: pedantic
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.11.1"
   permission_handler:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
     sdk: flutter
   http: ^0.13.4
   dio: ^4.0.1
-  flutter_local_notifications: ^9.0.0
+  flutter_local_notifications: ^10.0.0-dev.6
   rxdart: ^0.27.2
 
   path_provider: ^2.0.11


### PR DESCRIPTION
https://github.com/MaikuB/flutter_local_notifications/issues/1476
Upgrade fix crash on PendingIntent Android 12 / API 31